### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/AbstractArray.php
+++ b/AbstractArray.php
@@ -217,7 +217,7 @@ abstract class AbstractArray implements \Countable {
 	 *
 	 * @return $this
 	 */
-	public function sort(Comparator|callable $cmp = null): self {
+	public function sort(Comparator|callable|null $cmp = null): self {
 		$this->doSort($this->array, 'usort', 'sort', $cmp);
 
 		return $this;
@@ -231,7 +231,7 @@ abstract class AbstractArray implements \Countable {
 	 * @param callable                 $sort  the default sort function
 	 * @param Comparator|callable|null $cmp   the compare function
 	 */
-	protected function doSort(array & $array, callable $usort, callable $sort, Comparator|callable $cmp = null): void {
+	protected function doSort(array & $array, callable $usort, callable $sort, Comparator|callable|null $cmp = null): void {
 		if (is_callable($cmp)) {
 			$usort($array, $cmp);
 		} elseif ($cmp instanceof Comparator) {

--- a/parts/ComparisonPart.php
+++ b/parts/ComparisonPart.php
@@ -61,7 +61,7 @@ trait ComparisonPart {
 	 *
 	 * @psalm-suppress MixedInferredReturnType
 	 */
-	public function compare(string|Text $compare, callable $callback = null): int {
+	public function compare(string|Text $compare, ?callable $callback = null): int {
 		if ($callback === null) {
 			$callback = 'strcmp';
 		}

--- a/parts/SortAssocPart.php
+++ b/parts/SortAssocPart.php
@@ -19,7 +19,7 @@ trait SortAssocPart {
 	 *
 	 * @return $this
 	 */
-	public function sortAssoc(Comparator|callable $cmp = null): self {
+	public function sortAssoc(Comparator|callable|null $cmp = null): self {
 		$this->doSort($this->array, 'uasort', 'asort', $cmp);
 
 		return $this;
@@ -32,7 +32,7 @@ trait SortAssocPart {
 	 *
 	 * @return $this
 	 */
-	public function sortKeys(Comparator|callable $cmp = null): self {
+	public function sortKeys(Comparator|callable|null $cmp = null): self {
 		$this->doSort($this->array, 'uksort', 'ksort', $cmp);
 
 		return $this;


### PR DESCRIPTION
ref https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

Testing via docker
```
lang$ docker run --rm -v $(pwd):/mnt -w /mnt php:8.4.0alpha2-cli-alpine find . -type f -name '*.php' -exec php -l {} \;
```